### PR TITLE
feat(#43): push notifications

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const favicon = require('serve-favicon');
@@ -5,11 +6,18 @@ const logger = require('morgan');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const webpush = require('web-push');
 const index = require('./routes/index');
 const users = require('./routes/users');
 const internships = require('./routes/internships');
 const testimonial = require('./routes/testimonial');
-const teamMember = require('./routes/teamMember')
+const teamMember = require('./routes/teamMember');
+
+const publicVapidKey = process.env.PUBLIC_VAPID_KEY;
+const privateVapidKey = process.env.PRIVATE_VAPID_KEY;
+
+// Replace with your email
+webpush.setVapidDetails('mailto:sidbentifraouine@gmail.com', publicVapidKey, privateVapidKey);
 
 const app = express();
 
@@ -19,7 +27,6 @@ const db = require('./config/db');
 // view engine not required so commented it
 // app.set('views', path.join(__dirname, 'views'));
 // app.set('view engine', 'pug');
-
 
 // uncomment after placing your favicon in /public
 // app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
@@ -43,12 +50,26 @@ app.use(express.static(path.join(__dirname, 'public')));
 // });
 
 // Routes middleware
+app.post('/subscribe', (req, res) => {
+  const subscription = req.body;
+  res.status(201).json({});
+  const payload = JSON.stringify({ title: 'Hello from Backend' });
+
+  webpush
+    .sendNotification(subscription, payload)
+    .then(() => {
+      console.log('sendNotification success');
+    })
+    .catch((error) => {
+      console.error('sendNotification ERROR', error.stack);
+    });
+});
+
 app.use('/', index);
 app.use('/', users);
 app.use('/', internships);
 app.use('/', testimonial);
 app.use('/', teamMember);
-
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cors": "^2.8.4",
     "crypto": "^1.0.1",
     "debug": "~2.6.9",
+    "dotenv": "^6.1.0",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.2.0",
     "mocha": "^5.2.0",
@@ -55,7 +56,8 @@
     "nodemailer": "^4.6.5",
     "nyc": "^13.0.1",
     "pug": "2.0.0-beta11",
-    "serve-favicon": "~2.4.5"
+    "serve-favicon": "~2.4.5",
+    "web-push": "^3.3.3"
   },
   "devDependencies": {
     "eslint": "^5.6.1",


### PR DESCRIPTION
This comes in completion of this [PR](https://github.com/Ignitus/Ignitus-Client-Side-Development/pull/125PR)

## Description
@divyanshu-rawat 
I implemented a server to client push notification using `web-push`

## Configuration
You'll have to push your keys in a `.env`, here is how you generate them:
```bash
$ ./node_modules/.bin/web-push generate-vapid-keys
```
and then you put your public key on the client side.

```javascript
// registerServiceWorker.js
applicationServerKey: urlBase64ToUint8Array(PUBLIC_KEY)
```
## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
