### PR TITLE
Add route to fetch user info from JWT token

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -300,3 +300,29 @@ exports.professorlinkedlogin = function (req, res) {
 exports.professorlinkedlogincallback = function (req, res) {
   linkedinlogin(req, res, 'professor');
 };
+
+exports.getUserInfoFromToken = function (req, res) {
+  if ((req.headers && req.headers.authorization) || req.body.token) {
+    const authorization = req.headers.authorization || req.body.token;
+    try {
+      const decodedToken = jwt.verify(authorization, secret);
+      Users.findOne({
+        _id: decodedToken.userId,
+      }).then((user) => {
+        const {
+          email,
+          user_role,
+        } = user;
+        return responseHandler.success(res, {
+          email,
+          user_role,
+        });
+      })
+      .catch(err => responseHandler.error(res, 'User not found', 404));
+    } catch (e) {
+      return responseHandler.error(res, 'Unauthorized', 401);
+    }
+  } else {
+    return responseHandler.error(res, 'Unauthorized', 401);
+  }
+};

--- a/routes/users.js
+++ b/routes/users.js
@@ -24,4 +24,5 @@ router.get('/professor/oauth/linkedin/callback', Users.professorlinkedlogincallb
 // email verification route same for both the users
 router.get('/verify', Users.verify);
 
+router.post('/userinfofromtoken', Users.getUserInfoFromToken);
 module.exports = router;


### PR DESCRIPTION
* Add route and controller to fetch user info from JWT payload
* Fetch user info from token via request obj or from headers
* Fix for https://github.com/Ignitus/Ignitus-rest-api/issues/39

<!--- Provide a general summary of your changes in the Title above -->
* Add route and controller to fetch user info from JWT payload
* Fetch user info from token via request obj or from headers

## Description
<!--- Describe your changes in detail  -->

Valid token response:
{
	"statusCode": 200,
	"data": {
		"email": "test@gmail.com",
		"user_role": "student"
	},
	"message": "Success",
	"success": true
}


Err req/response:

{
	"token": ""
}

{
	"message": "Unauthorized",
	"statusCode": 401,
	"success": false
}
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Fix for https://github.com/Ignitus/Ignitus-rest-api/issues/39

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked with valid token , empty token in request object and authorisation headers
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
